### PR TITLE
Will not require additional SSH keys and can be accessed from anywhere

### DIFF
--- a/.my_commands.sh
+++ b/.my_commands.sh
@@ -1,15 +1,6 @@
 #!/bin/bash
-
+SCRIPTPATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 function create() {
-    cd
-    source .env
-    python create.py $1
-    cd $FILEPATH$1
-    git init
-    git remote add origin git@github.com:$USERNAME/$1.git
-    touch README.md
-    git add .
-    git commit -m "Initial commit"
-    git push -u origin master
-    code .
+    cd $SCRIPTPATH
+    python3 create.py $1
 }

--- a/create.py
+++ b/create.py
@@ -2,7 +2,7 @@ import sys
 import os
 from github import Github
 from dotenv import load_dotenv
-
+import pygit2
 load_dotenv()
 
 path = os.getenv("FILEPATH")
@@ -11,10 +11,13 @@ password = os.getenv("PASSWORD")
 
 def create():
     folderName = str(sys.argv[1])
-    os.makedirs(path + str(folderName))
     user = Github(username, password).get_user()
     repo = user.create_repo(folderName)
-    print("Succesfully created repository {}".format(folderName))
+    repo.create_file("README.md", "Initial commit","")
+    repoClone = pygit2.clone_repository(repo.git_url, path + str(folderName))
+    print(f"Succesfully created repository {folderName}")
+    os.chdir(path+str(folderName))
+    os.system("code .")
 
 if __name__ == "__main__":
     create()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 selenium
 PyGithub
 python-dotenv
+pygit2


### PR DESCRIPTION
GitHub requires you to have a public SSH key to push the files if the repository is added remotely, which may cause further errors. Instead, I created the README.md file using PyGithub and then cloned the repository into the folder using PyGit2.

I also fixed an issue where the files could not be accessed from any directory by storing the original location of the shell file and shifting most of the code into Python instead. 